### PR TITLE
从英文原文更新内容

### DIFF
--- a/src/3.4.生命周期的局限.md
+++ b/src/3.4.生命周期的局限.md
@@ -64,7 +64,7 @@ fn main() {
 
 这段程序显然完全符合引用的语义，但是我们的生命周期系统过于粗糙，无法对它进行正确的分析。
 
-# 不合理地减少借用
+# 不合理地减少借用(Improperly reduced borrows)
 下面的代码无法通过编译, 因为Rust不知道对map的可变借用已经不再需要了，并且保守性地让它在整个作用域内都有效。这个问题迟早会得到修复。
 ``` Rust
 fn get_default<'m, K, V>(map: &'m mut HashMap<K, V>, key: K) -> &'m mut V

--- a/src/3.4.生命周期的局限.md
+++ b/src/3.4.生命周期的局限.md
@@ -5,10 +5,11 @@
 考虑下面的代码：
 
 ``` Rust
+#[derive(Debug)]
 struct Foo;
 
 impl Foo {
-    fn mutate_and_share(&mut self) -> &Self {&*self}
+    fn mutate_and_share(&mut self) -> &Self { &*self }
     fn share(&self) {}
 }
 
@@ -16,6 +17,7 @@ fn main() {
     let mut foo = Foo;
     let loan = foo.mutate_and_share();
     foo.share();
+    println!("{:?}", loan);
 }
 ```
 
@@ -24,19 +26,14 @@ fn main() {
 但是当我们尝试编译它：
 
 ```
-<anon>:11:5: 11:8 error: cannot borrow `foo` as immutable because it is also borrowed as mutable
-<anon>:11     foo.share();
-              ^~~
-<anon>:10:16: 10:19 note: previous borrow of `foo` occurs here; the mutable borrow prevents subsequent moves, borrows, or modification of `foo` until the borrow ends
-<anon>:10     let loan = foo.mutate_and_share();
-                         ^~~
-<anon>:12:2: 12:2 note: previous borrow ends here
-<anon>:8 fn main() {
-<anon>:9     let mut foo = Foo;
-<anon>:10     let loan = foo.mutate_and_share();
-<anon>:11     foo.share();
-<anon>:12 }
-          ^
+error[E0502]: cannot borrow `foo` as immutable because it is also borrowed as mutable
+  --> src/main.rs:12:5
+   |
+11 |     let loan = foo.mutate_and_share();
+   |                --- mutable borrow occurs here
+12 |     foo.share();
+   |     ^^^ immutable borrow occurs here
+13 |     println!("{:?}", loan);
 ```
 
 发生了什么呢？嗯……我们遇到了和[上一章的示例2](https://doc.rust-lang.org/nomicon/lifetimes.html#example-aliasing-a-mutable-reference)相同的错误。我们去掉语法糖，会得到这样的代码:
@@ -57,6 +54,7 @@ fn main() {
             'd: {
                 Foo::share::<'d>(&'d foo);
             }
+            println!("{:?}", loan);
         }
     }
 }
@@ -66,4 +64,20 @@ fn main() {
 
 这段程序显然完全符合引用的语义，但是我们的生命周期系统过于粗糙，无法对它进行正确的分析。
 
-接下来，还有什么普遍的问题吗？关于SEME区域的，大概吧？
+# 不合理地减少借用
+下面的代码无法通过编译, 因为Rust不知道对map的可变借用已经不再需要了，并且保守性地让它在整个作用域内都有效。这个问题迟早会得到修复。
+``` Rust
+fn get_default<'m, K, V>(map: &'m mut HashMap<K, V>, key: K) -> &'m mut V
+where
+    K: Clone + Eq + Hash,
+    V: Default,
+{
+    match map.get_mut(&key) {
+        Some(value) => value,
+        None => {
+            map.insert(key.clone(), V::default());
+            map.get_mut(&key).unwrap()
+        }
+    }
+}
+```


### PR DESCRIPTION
原文地址 https://doc.rust-lang.org/nomicon/lifetime-mismatch.html
变更内容：
* 略微修改了程序源代码
* 变更了编译器诊断信息的格式
* 新增了一小段关于Improperly reduced borrows的内容